### PR TITLE
Feature/interrupt support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,11 @@
 .piolibdeps
 /external/unity/*-repo/
 /build/
+/.cproject
+/.project
+**/CMakeFiles/*
+**/CMakeCache.txt
+**/*.cmake
+**/Makefile
+!/Makefile
+/Testing/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,98 @@
+# Contribution Guidelines
+This is a step-by-step guide for contributors.
+
+## Adding missing function
+I was missing `sei()`, `cli()` and `attachInterrupt()` in ArduinoFake, here is list of steps I did.
+
+
+1. add definitions of new functions in [src/arduino/Arduino.h](/src/arduino/Arduino.h), check if your function is in [Arduino.h](/src/arduino/Arduino.h). There are two situations: 
+    * `attachInterrupt()` was already in [Arduino.h](/src/arduino/Arduino.h) so we are done. 
+    * `sei()` was not defined in [Arduino.h](/src/arduino/Arduino.h) so
+       * create a new header file [avr/interrupt.h](/src/arduino/avr/interrupt.h) to cover interrupt related definitions with a content
+          ```c
+          /**
+           * Fake version of avr/interrupt.h
+           */
+          void cli(void);
+          void sei(void);          
+       * add `#include "avr/interrupt.h"` in [Arduino.h](/src/arduino/Arduino.h)
+1. Find approriate place for your functions, in my case I extended [src/FunctionFake.h](/src/FunctionFake.h) for new functions
+	```c++
+    struct FunctionFake
+	{
+    	...
+		virtual void attachInterrupt(uint8_t, void (*)(void), int mode) = 0;
+    	virtual void cli() = 0;
+    	virtual void sei() = 0;
+        ...
+    }
+    ```    
+1. add default implementations into corresponding cpp file, in my case [src/FunctionFake.cpp](/src/FunctionFake.cpp).
+	```c++
+    void attachInterrupt(uint8_t interruptNum, void (*userFunc)(void), int mode) {
+        ArduinoFakeInstance(Function)->attachInterrupt(interruptNum, userFunc, mode);
+    }
+
+    void cli(void) {
+        ArduinoFakeInstance(Function)->cli();
+    }
+
+    void sei(void) {
+        ArduinoFakeInstance(Function)->sei();
+    }
+	```
+1. **don't forgot to add TESTs** for new functionality, at least test if a function can be executed, in my case [test/test_functio.h](/test/test_functio.h)
+	```c++
+    void test_attach(void)
+    {
+        When(Method(ArduinoFake(), attachInterrupt)).AlwaysReturn();
+
+        attachInterrupt(1, (void (*)(void))NULL, FALLING);
+        attachInterrupt(2, (void (*)(void))NULL, CHANGE);
+        attachInterrupt(3, (void (*)(void))NULL, RISING);
+
+        Verify(Method(ArduinoFake(), attachInterrupt)).Exactly(3);
+    }
+
+    void test_cli(void)
+    {
+        When(Method(ArduinoFake(), cli)).AlwaysReturn();
+
+        cli();
+
+        Verify(Method(ArduinoFake(), cli)).Once();
+    }
+
+    void test_sei(void)
+    {
+        When(Method(ArduinoFake(), sei)).AlwaysReturn();
+
+        sei();
+
+        Verify(Method(ArduinoFake(), sei)).Once();
+    }
+    ```
+    and add tests to test list
+    ```c
+    void run_tests(void)
+    {
+		...
+		RUN_TEST(FunctionTest::test_attach);
+        RUN_TEST(FunctionTest::test_cli);        
+        RUN_TEST(FunctionTest::test_sei);
+		...
+    }
+1. excersice tests from command line
+   ```
+   make clean all && test/main
+   ```
+   verify PASS of all tests	
+   ```
+    .../ArduinoFake/test/main.cpp:184:FunctionTest::test_attach:PASS
+    .../ArduinoFake/test/main.cpp:185:FunctionTest::test_sei:PASS
+    .../ArduinoFake/test/main.cpp:186:FunctionTest::test_cli:PASS
+
+    -----------------------
+    39 Tests 0 Failures 0 Ignored 
+    OK
+   ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ I was missing `sei()`, `cli()` and `attachInterrupt()` in ArduinoFake, here is l
     * `attachInterrupt()` was already in [Arduino.h](/src/arduino/Arduino.h) so we are done. 
     * `sei()` was not defined in [Arduino.h](/src/arduino/Arduino.h) so
        * create a new header file [avr/interrupt.h](/src/arduino/avr/interrupt.h) to cover interrupt related definitions with a content
-          ```c
+          ```c++
           /**
            * Fake version of avr/interrupt.h
            */
@@ -18,14 +18,14 @@ I was missing `sei()`, `cli()` and `attachInterrupt()` in ArduinoFake, here is l
        * add `#include "avr/interrupt.h"` in [Arduino.h](/src/arduino/Arduino.h)
 1. Find approriate place for your functions, in my case I extended [src/FunctionFake.h](/src/FunctionFake.h) for new functions
 	```c++
-    struct FunctionFake
+	struct FunctionFake
 	{
-    	...
+		...
 		virtual void attachInterrupt(uint8_t, void (*)(void), int mode) = 0;
-    	virtual void cli() = 0;
-    	virtual void sei() = 0;
-        ...
-    }
+		virtual void cli() = 0;
+		virtual void sei() = 0;
+		...
+	}
     ```    
 1. add default implementations into corresponding cpp file, in my case [src/FunctionFake.cpp](/src/FunctionFake.cpp).
 	```c++
@@ -41,7 +41,7 @@ I was missing `sei()`, `cli()` and `attachInterrupt()` in ArduinoFake, here is l
         ArduinoFakeInstance(Function)->sei();
     }
 	```
-1. **don't forgot to add TESTs** for new functionality, at least test if a function can be executed, in my case [test/test_functio.h](/test/test_functio.h)
+1. **don't forget to add TESTs** for new functionality, at least test if a function can be executed, in my case [test/test_function.h](/test/test_function.h)
 	```c++
     void test_attach(void)
     {
@@ -78,20 +78,32 @@ I was missing `sei()`, `cli()` and `attachInterrupt()` in ArduinoFake, here is l
     {
 		...
 		RUN_TEST(FunctionTest::test_attach);
-        RUN_TEST(FunctionTest::test_cli);        
-        RUN_TEST(FunctionTest::test_sei);
+		RUN_TEST(FunctionTest::test_cli);        
+		RUN_TEST(FunctionTest::test_sei);
 		...
     }
-1. excersice tests from command line
+1. excersice tests from command line, there are two ways based on your Makefile
+   * default project [Makefile](/Makefile), 
+     * execute `make`  
+     * verify
    ```
-   make clean all && test/main
+	Running tests...
+	Test project /home/vlcvi01/Dropbox/git/ArduinoFake/build
+	    Start 1: main
+	1/1 Test #1: main .............................   Passed    0.01 sec
+
+	100% tests passed, 0 tests failed out of 1
    ```
-   verify PASS of all tests	
+   * [eclipse based Makefile](https://www.mantidproject.org/Setting_up_Eclipse_projects_with_CMake) generated via `cmake -G "Eclipse CDT4 - Unix Makefiles"`.
+     * execute `make clean all && test/main`
+     * verify PASS of all tests	
    ```
+    ...
     .../ArduinoFake/test/main.cpp:184:FunctionTest::test_attach:PASS
     .../ArduinoFake/test/main.cpp:185:FunctionTest::test_sei:PASS
     .../ArduinoFake/test/main.cpp:186:FunctionTest::test_cli:PASS
-
+    ...
+    
     -----------------------
     39 Tests 0 Failures 0 Ignored 
     OK

--- a/README.md
+++ b/README.md
@@ -56,3 +56,6 @@ void test_loop(void)
 
 Checkout the [examples](./examples) for many more examples!
 Or take a look at the [tests](./test)
+
+# Contributing
+If you want to extend Arduino Fake library to add missing functions (for example  `attachInterrupt`) see [contribution guidelines](CONTRIBUTING.md).

--- a/src/FunctionFake.cpp
+++ b/src/FunctionFake.cpp
@@ -74,6 +74,18 @@ void detachInterrupt(uint8_t interruptNum) {
     ArduinoFakeInstance(Function)->detachInterrupt(interruptNum);
 }
 
+void attachInterrupt(uint8_t interruptNum, void (*userFunc)(void), int mode) {
+	ArduinoFakeInstance(Function)->attachInterrupt(interruptNum, userFunc, mode);
+}
+
+void cli(void) {
+    ArduinoFakeInstance(Function)->cli();
+}
+
+void sei(void) {
+    ArduinoFakeInstance(Function)->sei();
+}
+
 void tone(uint8_t pin, unsigned int frequency, unsigned long duration)
 {
     ArduinoFakeInstance(Function)->tone(pin, frequency, duration);

--- a/src/FunctionFake.h
+++ b/src/FunctionFake.h
@@ -29,6 +29,9 @@ struct FunctionFake
     virtual uint8_t shiftIn(uint8_t, uint8_t, uint8_t) = 0;
 
     virtual void detachInterrupt(uint8_t) = 0;
+    virtual void attachInterrupt(uint8_t, void (*)(void), int mode) = 0;
+    virtual void cli() = 0;
+    virtual void sei() = 0;
 
     virtual void tone(uint8_t _pin, unsigned int frequency, unsigned long duration) = 0;
     virtual void noTone(uint8_t _pin) = 0;

--- a/src/arduino/Arduino.h
+++ b/src/arduino/Arduino.h
@@ -25,6 +25,8 @@
 #include <stdbool.h>
 #include <string.h>
 #include <math.h>
+#include "avr/interrupt.h"
+
 
 #include "binary.h"
 

--- a/src/arduino/avr/interrupt.h
+++ b/src/arduino/avr/interrupt.h
@@ -1,0 +1,5 @@
+/**
+ * Fake version of avr/interrupt.h
+ */
+void cli(void);
+void sei(void);

--- a/test/test_function.h
+++ b/test/test_function.h
@@ -91,6 +91,35 @@ namespace FunctionTest
         Verify(Method(ArduinoFake(), detachInterrupt).Using(1)).Once();
     }
 
+    void test_attach(void)
+    {
+        When(Method(ArduinoFake(), attachInterrupt)).AlwaysReturn();
+
+        attachInterrupt(1, (void (*)(void))NULL, FALLING);
+        attachInterrupt(2, (void (*)(void))NULL, CHANGE);
+        attachInterrupt(3, (void (*)(void))NULL, RISING);
+
+        Verify(Method(ArduinoFake(), attachInterrupt)).Exactly(3);
+    }
+
+    void test_cli(void)
+    {
+        When(Method(ArduinoFake(), cli)).AlwaysReturn();
+
+        cli();
+
+        Verify(Method(ArduinoFake(), cli)).Once();
+    }
+
+    void test_sei(void)
+    {
+        When(Method(ArduinoFake(), sei)).AlwaysReturn();
+
+        sei();
+
+        Verify(Method(ArduinoFake(), sei)).Once();
+    }
+
     void test_random(void)
     {
         When(Method(ArduinoFake(), randomSeed)).AlwaysReturn();
@@ -152,6 +181,9 @@ namespace FunctionTest
         RUN_TEST(FunctionTest::test_analog_pin);
         RUN_TEST(FunctionTest::test_delay);
         RUN_TEST(FunctionTest::test_detach);
+        RUN_TEST(FunctionTest::test_attach);
+        RUN_TEST(FunctionTest::test_cli);        
+        RUN_TEST(FunctionTest::test_sei);
         RUN_TEST(FunctionTest::test_pulsein);
         RUN_TEST(FunctionTest::test_shift);
         RUN_TEST(FunctionTest::test_random);


### PR DESCRIPTION
 * Support for interrupt related functions like `sei()`, `cli()` and `attachInterrupt()`
 * Added contribution guidelines - CONTRIBUTING.md description how to add missing functions to arduino mocks
* Added ignored files on .gitignore
  * /.cproject
  * /.project
  * **/CMakeFiles/*
  * **/CMakeCache.txt
  * **/*.cmake
  * **/Makefile
  * !/Makefile
  * /Testing/*