### PR TITLE
support for interrupt related functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ matrix:
         -
             compiler: gcc
             env:
+                - MAKE_TASK=pio-test
                 - COMPILER=g++-5
-                - MAKE_TASK=cmake-test
                 - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
             addons:
                 apt:
@@ -26,8 +26,8 @@ matrix:
         -
             compiler: gcc
             env:
-                - COMPILER=g++-5
                 - MAKE_TASK=cmake-test
+                - COMPILER=g++-5
                 - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
             addons:
                 apt:
@@ -67,4 +67,4 @@ matrix:
                         - llvm-toolchain-precise-3.6
 
 script:
-    - "make $MAKE_TASKS"
+    - "make $MAKE_TASK"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ matrix:
             env:
                 - MAKE_TASK=pio-test
                 - COMPILER=g++-5
-                - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
             addons:
                 apt:
                     packages:
@@ -28,7 +27,6 @@ matrix:
             env:
                 - MAKE_TASK=cmake-test
                 - COMPILER=g++-5
-                - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
             addons:
                 apt:
                     packages:
@@ -42,7 +40,6 @@ matrix:
             env:
                 - MAKE_TASK=pio-test
                 - COMPILER=clang++-3.6
-                - MATRIX_EVAL="CC=clang-3.6 && CXX=clang++-3.6"
             addons:
                 apt:
                     packages:
@@ -56,7 +53,6 @@ matrix:
             env:
                 - MAKE_TASK=cmake-test
                 - COMPILER=clang++-3.6
-                - MATRIX_EVAL="CC=clang-3.6 && CXX=clang++-3.6"
             addons:
                 apt:
                     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,10 @@ matrix:
     include:
         -
             compiler: gcc
-            env: COMPILER=g++-5
+            env:
+                - COMPILER=g++-5
+                - MAKE_TASK=cmake-test
+                - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
             addons:
                 apt:
                     packages:
@@ -21,8 +24,39 @@ matrix:
                     sources:
                         - ubuntu-toolchain-r-test
         -
+            compiler: gcc
+            env:
+                - COMPILER=g++-5
+                - MAKE_TASK=cmake-test
+                - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+            addons:
+                apt:
+                    packages:
+                        - git
+                        - g++-5
+                    sources:
+                        - ubuntu-toolchain-r-test
+
+        -
             compiler: clang
-            env: COMPILER=clang++-3.6
+            env:
+                - MAKE_TASK=pio-test
+                - COMPILER=clang++-3.6
+                - MATRIX_EVAL="CC=clang-3.6 && CXX=clang++-3.6"
+            addons:
+                apt:
+                    packages:
+                        - git
+                        - clang-3.6
+                    sources:
+                        - ubuntu-toolchain-r-test
+                        - llvm-toolchain-precise-3.6
+        -
+            compiler: clang
+            env:
+                - MAKE_TASK=cmake-test
+                - COMPILER=clang++-3.6
+                - MATRIX_EVAL="CC=clang-3.6 && CXX=clang++-3.6"
             addons:
                 apt:
                     packages:
@@ -33,4 +67,4 @@ matrix:
                         - llvm-toolchain-precise-3.6
 
 script:
-    - "make pio-test"
+    - "make $MAKE_TASKS"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 This is a step-by-step guide for contributors.
 
 ## Adding missing function
-I was missing `sei()`, `cli()` and `attachInterrupt()` in ArduinoFake, here is list of steps I did.
+I was missing `sei()`, `cli()` and `attachInterrupt()` in `ArduinoFake`, here is list of steps I did.
 
 
 1. add definitions of new functions in [src/arduino/Arduino.h](/src/arduino/Arduino.h), check if your function is in [Arduino.h](/src/arduino/Arduino.h). There are two situations: 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ test:
 pio-test:
 	@pio test
 
+.PHONY: cmake-test
+cmake-test: build test
+
 .PHONY: clean
 clean:
 	@rm -rf $(CURDIR)/build/*

--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ Checkout the [examples](./examples) for many more examples!
 Or take a look at the [tests](./test)
 
 # Contributing
-If you want to extend Arduino Fake library to add missing functions (for example  `attachInterrupt`) see [contribution guidelines](CONTRIBUTING.md).
+If you want to extend `ArduinoFake` library to add missing functions (for example  `attachInterrupt`) see [contribution guidelines](CONTRIBUTING.md).

--- a/src/arduino/noniso.c
+++ b/src/arduino/noniso.c
@@ -166,7 +166,7 @@ extern char* ultoa( unsigned long value, char *string, int radix )
 }
 
 char *dtostrf (double val, signed char width, unsigned char prec, char *sout) {
-  asm(".global _printf_float");
+  //asm(".global _printf_float");
 
   char fmt[20];
   sprintf(fmt, "%%%d.%df", width, prec);

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -10,6 +10,7 @@ using namespace fakeit;
 #include "test_stream.h"
 #include "test_serial.h"
 #include "test_client.h"
+#include "test_arduino_string.h"
 
 #ifdef UNIT_TEST
 
@@ -26,6 +27,8 @@ void setUp(void)
 int main(int argc, char **argv)
 {
     UNITY_BEGIN();
+
+    RUN_TEST_GROUP(ArduinoStringTest);
 
     RUN_TEST_GROUP(ArduinoContextTest);
     RUN_TEST_GROUP(FunctionTest);

--- a/test/test_arduino_string.h
+++ b/test/test_arduino_string.h
@@ -1,0 +1,37 @@
+#ifdef UNIT_TEST
+
+namespace ArduinoStringTest
+{
+    void test_constructors(void)
+    {
+        String string01 = "Hello String";
+        String string02 = String('a');
+        String string03 = String("This is a string");
+        String string04 = String(string03 + " with more");
+        String string05 = String(13);
+        String string06 = String(1000, DEC);
+        String string07 = String(45, HEX);
+        String string08 = String(255, BIN);
+        String string09 = String(20000L, DEC);
+        String string10 = String(5.698, 3);
+
+        TEST_ASSERT_EQUAL_STRING("Hello String", string01.c_str());
+        TEST_ASSERT_EQUAL_STRING("a", string02.c_str());
+        TEST_ASSERT_EQUAL_STRING("This is a string", string03.c_str());
+        TEST_ASSERT_EQUAL_STRING("This is a string with more", string04.c_str());
+
+        TEST_ASSERT_EQUAL_STRING("13", string05.c_str());
+        TEST_ASSERT_EQUAL_STRING("1000", string06.c_str());
+        TEST_ASSERT_EQUAL_STRING("2d", string07.c_str());
+        TEST_ASSERT_EQUAL_STRING("11111111", string08.c_str());
+        TEST_ASSERT_EQUAL_STRING("20000", string09.c_str());
+        TEST_ASSERT_EQUAL_STRING("5.698", string10.c_str());
+    }
+
+    void run_tests()
+    {
+        RUN_TEST(ArduinoStringTest::test_constructors);
+    }
+}
+
+#endif


### PR DESCRIPTION
 * Support for interrupt related functions like `sei()`, `cli()` and `attachInterrupt()`
 * Added contribution guidelines - CONTRIBUTING.md description how to add missing functions to arduino mocks
* Added ignored files on .gitignore
  * /.cproject
  * /.project
  * **/CMakeFiles/*
  * **/CMakeCache.txt
  * **/*.cmake
  * **/Makefile
  * !/Makefile
  * /Testing/*