### PR TITLE
Override default compat mode in PlatformIO manifest

### DIFF
--- a/library.json
+++ b/library.json
@@ -14,6 +14,9 @@
   "exclude": [
     "test"
   ],
+  "build": {
+    "libCompatMode": "off"
+  },
   "frameworks": "arduino",
   "platforms": "native"
 }


### PR DESCRIPTION
Please consider merging this PR since the default compatibility mode value is `soft` that prohibits compilation of this library if no `framework` field is specified in `platformio.ini` file (which is the default choice for `native` platform). 
Thanks!