### PR TITLE
Move #include statements from WString.cpp to WString.h

### DIFF
--- a/src/arduino/WString.cpp
+++ b/src/arduino/WString.cpp
@@ -20,8 +20,6 @@
 */
 
 #include "WString.h"
-#include "pgmspace.h"
-#include "noniso.h"
 
 /*********************************************/
 /*  Constructors                             */

--- a/src/arduino/WString.h
+++ b/src/arduino/WString.h
@@ -21,6 +21,10 @@
 
 #ifndef String_class_h
 #define String_class_h
+
+#include "pgmspace.h"
+#include "noniso.h"
+
 #ifdef __cplusplus
 
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -11,6 +11,7 @@ using namespace fakeit;
 #include "test_serial.h"
 #include "test_client.h"
 #include "test_arduino_string.h"
+#include "test_include.h"
 
 #ifdef UNIT_TEST
 
@@ -36,6 +37,7 @@ int main(int argc, char **argv)
     RUN_TEST_GROUP(StreamTest);
     RUN_TEST_GROUP(SerialTest);
     RUN_TEST_GROUP(ClientTest);
+    RUN_TEST_GROUP(IncludeTest);
 
     UNITY_END();
 

--- a/test/test_include.h
+++ b/test/test_include.h
@@ -1,0 +1,17 @@
+#ifdef UNIT_TEST
+
+namespace IncludeTest
+{
+
+    void test_empty(void)
+    {
+        int PROGMEM a = 1;
+    }
+
+    void run_tests(void)
+    {
+        RUN_TEST(IncludeTest::test_empty);
+    }
+}
+
+#endif


### PR DESCRIPTION
As per issue #7 the `#include` statements for pgmspace.h and noniso.h need to move to WString.h instead of being in WString.cpp, so external libraries can access them too.