### PR TITLE
avoid clashes with std::min and std:max from STL

### DIFF
--- a/src/arduino/Arduino.h
+++ b/src/arduino/Arduino.h
@@ -88,8 +88,10 @@ void yield(void);
 #undef abs
 #endif
 
+#ifndef __cplusplus
 #define min(a,b) ((a)<(b)?(a):(b))
 #define max(a,b) ((a)>(b)?(a):(b))
+#endif
 #define abs(x) ((x)>0?(x):-(x))
 #define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
 #define round(x)     ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))


### PR DESCRIPTION
The definitions for min() and max in src/arduino/Arduino.h produce a lot of errors when using STL (for example with googletest) like this:

```
/usr/include/c++/7/limits:1002:11: error: macro "max" requires 2 arguments, but only 1 given
       max() _GLIBCXX_USE_NOEXCEPT { return __INT_MAX__; }
           ^
/usr/include/c++/7/limits:1006:38: error: macro "min" requires 2 arguments, but only 1 given
       lowest() noexcept { return min(); }
                                      ^
```
This minor patch avoids that.

Please accept this PR.