### PR TITLE
Add missing Wire.h header for WireFake.h

### DIFF
--- a/src/Wire.h
+++ b/src/Wire.h
@@ -1,0 +1,1 @@
+#include "WireFake.h"


### PR DESCRIPTION
Hey there, great project!

I struggled to get my library completely independent from the Arduino framework as I didn't want to use virtualization. Therefore using ArduinoFake for a "Link Seam" approach seemed the right choice, as I didn't want to alter my source too much. That worked flawlessly with the Arduino functions - great!

I noticed that for the standard `Arduino.h` header there is a header that `#include "ArduinoFake.h"` and thus makes the  whole
```
#ifdef UNIT_TEST
#include <ArduinoFake.h>
#else
#include <Arduino.h>
#endif
```
shenanigans inside my library superfluous (as in the `mock-injection` example as opposed to the `wiring-blink` example). To make the same thing work for the new `WireFake.h` I added a `Wire.h` that just includes the fake.

I hope this small addition is fine like this - it seems to be working for me.
Please tell me if there's anything else I should add/edit.

Cheers,
Max