### PR TITLE
Include the "real" files instead of the Fakes

### DIFF
--- a/src/ArduinoFake.h
+++ b/src/ArduinoFake.h
@@ -12,13 +12,13 @@
 
 #include "arduino/Arduino.h"
 
-#include "FunctionFake.h"
-#include "StreamFake.h"
-#include "SerialFake.h"
-#include "WireFake.h"
-#include "ClientFake.h"
-#include "PrintFake.h"
-#include "SPIFake.h"
+#include "Function.h"
+#include "Stream.h"
+#include "Serial.h"
+#include "Wire.h"
+#include "Client.h"
+#include "Print.h"
+#include "SPI.h"
 
 #define ArduinoFake(mock) _ArduinoFakeGet##mock()
 

--- a/src/Function.h
+++ b/src/Function.h
@@ -1,0 +1,1 @@
+#include "FunctionFake.h"

--- a/src/Print.h
+++ b/src/Print.h
@@ -1,0 +1,1 @@
+#include "PrintFake.h"

--- a/src/Serial.h
+++ b/src/Serial.h
@@ -1,0 +1,1 @@
+#include "SerialFake.h"

--- a/src/Stream.h
+++ b/src/Stream.h
@@ -1,0 +1,1 @@
+#include "StreamFake.h"


### PR DESCRIPTION
Doing it this way allows PlatformIO to find the correct include files so that existing libraries still work.

This should address #39.