### PR TITLE
Add support for the Arduino EEPROM class.

### DIFF
--- a/src/ArduinoFake.h
+++ b/src/ArduinoFake.h
@@ -1,4 +1,5 @@
 #pragma once
+// clang-format off
 
 #if !defined(UBRRH) && !defined(UBRR0H) && !defined(USBCON)
     #define USBCON
@@ -19,6 +20,7 @@
 #include "Client.h"
 #include "Print.h"
 #include "SPI.h"
+#include "EEPROM.h"
 
 #define ArduinoFake(mock) _ArduinoFakeGet##mock()
 
@@ -38,6 +40,7 @@
 #define _ArduinoFakeGetSerial() _ArduinoFakeGetMock(Serial)
 #define _ArduinoFakeGetWire() _ArduinoFakeGetMock(Wire)
 #define _ArduinoFakeGetSPI() _ArduinoFakeGetMock(SPI)
+#define _ArduinoFakeGetEEPROM() _ArduinoFakeGetMock(EEPROM)
 #define _ArduinoFakeGetStream() _ArduinoFakeGetMock(Stream)
 #define _ArduinoFakeGetClient() _ArduinoFakeGetMock(Client)
 #define _ArduinoFakeGetPrint() _ArduinoFakeGetMock(Print)
@@ -73,6 +76,7 @@ struct ArduinoFakeMocks
     fakeit::Mock<ClientFake> Client;
     fakeit::Mock<PrintFake> Print;
     fakeit::Mock<SPIFake> SPI;
+    fakeit::Mock<EEPROMFake> EEPROM;
 };
 
 struct ArduinoFakeInstances
@@ -84,6 +88,7 @@ struct ArduinoFakeInstances
     ClientFake* Client;
     PrintFake* Print;
     SPIFake* SPI;
+    EEPROMFake* EEPROM;
 };
 
 class ArduinoFakeContext
@@ -100,6 +105,7 @@ class ArduinoFakeContext
         _ArduinoFakeInstanceGetter1(Client)
         _ArduinoFakeInstanceGetter1(Function)
         _ArduinoFakeInstanceGetter1(SPI)
+        _ArduinoFakeInstanceGetter1(EEPROM)
 
         _ArduinoFakeInstanceGetter2(Print, Print)
         _ArduinoFakeInstanceGetter2(Client, Client)
@@ -107,6 +113,7 @@ class ArduinoFakeContext
         _ArduinoFakeInstanceGetter2(Serial, Serial_)
         _ArduinoFakeInstanceGetter2(Wire, TwoWire)
         _ArduinoFakeInstanceGetter2(SPI, SPIClass)
+        _ArduinoFakeInstanceGetter2(EEPROM, EEPROMClass)
 
         ArduinoFakeContext()
         {
@@ -124,11 +131,15 @@ class ArduinoFakeContext
             this->Mocks->Client.Reset();
             this->Mocks->Print.Reset();
             this->Mocks->SPI.Reset();
+            this->Mocks->EEPROM.Reset();
 
             Mapping[&::Serial] = this->Serial();
             Mapping[&::Wire] = this->Wire();
             Mapping[&::SPI] = this->SPI();
+            Mapping[&::EEPROM] = this->EEPROM();
         }
 };
 
 ArduinoFakeContext* getArduinoFakeContext();
+
+// clang-format on

--- a/src/EEPROM.h
+++ b/src/EEPROM.h
@@ -1,0 +1,1 @@
+#include "EEPROMFake.h"

--- a/src/EEPROMFake.cpp
+++ b/src/EEPROMFake.cpp
@@ -1,0 +1,17 @@
+// clang-format off
+#include "ArduinoFake.h"
+#include "EEPROMFake.h"
+// clang-format on
+
+uint8_t EEPROMClass::read(int idx) {
+  return ArduinoFakeInstance(EEPROM)->read(idx);
+};
+void EEPROMClass::write(int idx, uint8_t val) {
+  ArduinoFakeInstance(EEPROM)->write(idx, val);
+};
+void EEPROMClass::update(int idx, uint8_t val) {
+  ArduinoFakeInstance(EEPROM)->update(idx, val);
+};
+uint16_t EEPROMClass::length() { return ArduinoFakeInstance(EEPROM)->length(); }
+
+EEPROMClass EEPROM = EEPROMFakeProxy(ArduinoFakeInstance(EEPROM));

--- a/src/EEPROMFake.h
+++ b/src/EEPROMFake.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "ArduinoFake.h"
+#include "arduino/EEPROM.h"
+
+struct EEPROMFake {
+  virtual uint8_t read(int idx) = 0;
+  virtual void write(int idx, uint8_t val) = 0;
+  virtual void update(int idx, uint8_t val) = 0;
+  virtual uint16_t length() = 0;
+};
+
+class EEPROMFakeProxy : public EEPROMClass {
+private:
+  EEPROMFake *eepromFake;
+
+public:
+  EEPROMFakeProxy(EEPROMFake *fake) { eepromFake = fake; }
+
+  EEPROMFake *getEEPROMFake() { return eepromFake; }
+};

--- a/src/arduino/EEPROM.h
+++ b/src/arduino/EEPROM.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <inttypes.h>
+
+struct EEPROMClass {
+  virtual uint8_t read(int idx);
+  virtual void write(int idx, uint8_t val);
+  virtual void update(int idx, uint8_t val);
+  virtual uint16_t length();
+  /*
+  EERef operator[](const int idx);
+
+  // TODO: How to implement this functionality??
+  // https://docs.arduino.cc/learn/built-in-libraries/eeprom
+  template <typename T> T &get(int idx, T &t);
+
+  template <typename T> const T &put(int idx, const T &t);
+  */
+};
+
+extern EEPROMClass EEPROM;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,3 +1,4 @@
+// clang-format off
 #include <Arduino.h>
 #include <cstdlib>
 #include <unity.h>
@@ -11,6 +12,7 @@ using namespace fakeit;
 #include "test_serial.h"
 #include "test_wire.h"
 #include "test_spi.h"
+#include "test_eeprom.h"
 #include "test_client.h"
 #include "test_arduino_string.h"
 #include "test_include.h"
@@ -40,6 +42,7 @@ int main(int argc, char **argv)
     RUN_TEST_GROUP(SerialTest);
     RUN_TEST_GROUP(WireTest);
     RUN_TEST_GROUP(SpiTest);
+    RUN_TEST_GROUP(EEPROMTest);
     RUN_TEST_GROUP(ClientTest);
     RUN_TEST_GROUP(IncludeTest);
 
@@ -49,3 +52,4 @@ int main(int argc, char **argv)
 }
 
 #endif
+// clang-format on

--- a/test/test_eeprom.h
+++ b/test/test_eeprom.h
@@ -1,0 +1,33 @@
+#ifdef UNIT_TEST
+
+namespace EEPROMTest {
+
+#include "arduino/EEPROM.h"
+
+void test_basics(void) {
+  When(OverloadedMethod(ArduinoFake(EEPROM), read, uint8_t(int)))
+      .AlwaysReturn();
+  When(OverloadedMethod(ArduinoFake(EEPROM), write, void(int, uint8_t)))
+      .AlwaysReturn();
+  When(OverloadedMethod(ArduinoFake(EEPROM), update, void(int, uint8_t)))
+      .AlwaysReturn();
+  When(OverloadedMethod(ArduinoFake(EEPROM), length, uint16_t(void)))
+      .AlwaysReturn();
+
+  EEPROM.read(1);
+  EEPROM.write(1, 1);
+  EEPROM.update(1, 2);
+  EEPROM.length();
+
+  Verify(OverloadedMethod(ArduinoFake(EEPROM), read, uint8_t(int))).Once();
+  Verify(OverloadedMethod(ArduinoFake(EEPROM), write, void(int, uint8_t)))
+      .Once();
+  Verify(OverloadedMethod(ArduinoFake(EEPROM), update, void(int, uint8_t)))
+      .Once();
+  Verify(OverloadedMethod(ArduinoFake(EEPROM), length, uint16_t(void))).Once();
+}
+
+void run_tests() { RUN_TEST(EEPROMTest::test_basics); }
+} // namespace EEPROMTest
+
+#endif


### PR DESCRIPTION
This partially addresses #40 
_Note: For now, this only supports the simple methods. `get/put` aren't implemented because virtual template functions are not a thing._