### PR TITLE
Expose arduino/Wstring.h

### DIFF
--- a/src/WString.h
+++ b/src/WString.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "arduino/WString.h"


### PR DESCRIPTION
Expose arduino/Wstring.h to be able to be used directly with
#include <WString.h>

Fixes WString.h file is missing when #include <WString.h> is declared and Arduino.h or ArduinoFake.h is not included.