### PR TITLE
Adding "setDebugOutput()" Methode to SerialFake

### DIFF
--- a/src/SerialFake.cpp
+++ b/src/SerialFake.cpp
@@ -83,6 +83,10 @@ bool Serial_::rts()
     return ArduinoFakeInstance(Serial, this)->rts();
 }
 
+void Serial_::setDebugOutput(bool _value){
+    return ArduinoFakeInstance(Serial, this) -> setDebugOutput(_value);
+}
+
 int32_t Serial_::readBreak()
 {
     return ArduinoFakeInstance(Serial, this)->readBreak();

--- a/src/SerialFake.h
+++ b/src/SerialFake.h
@@ -28,6 +28,8 @@ struct SerialFake : public StreamFake
     virtual uint8_t numbits() = 0;
     virtual bool dtr() = 0;
     virtual bool rts() = 0;
+
+    virtual void setDebugOutput(bool) = 0;
 };
 
 class SerialFakeProxy : public StreamFakeProxy, public Serial_

--- a/src/arduino/USBAPI.h
+++ b/src/arduino/USBAPI.h
@@ -105,6 +105,8 @@ public:
 	volatile uint8_t _rx_buffer_tail;
 	unsigned char _rx_buffer[SERIAL_BUFFER_SIZE];
 
+	virtual void setDebugOutput(bool);
+
 	// This method allows processing "SEND_BREAK" requests sent by
 	// the USB host. Those requests indicate that the host wants to
 	// send a BREAK signal and are accompanied by a single uint16_t


### PR DESCRIPTION
I added now the setDebugOutput Methode to the SerialFake file.
As I mentioned, it is not possible to me, testing with Cmake. So this are untested changes which are working for me locally while unit testing within native environment. See #62 .