### PR TITLE
Add SPI transfer16 method

### DIFF
--- a/src/SPIFake.cpp
+++ b/src/SPIFake.cpp
@@ -17,6 +17,10 @@ uint8_t SPIClass::transfer(uint8_t data) {
   return ArduinoFakeInstance(SPI)->transfer(data);
 };
 
+uint16_t SPIClass::transfer16(uint16_t data) {
+  return ArduinoFakeInstance(SPI)->transfer16(data);
+};
+
 void SPIClass::transfer(void *buf, size_t count) {
   return ArduinoFakeInstance(SPI)->transfer(buf, count);
 };

--- a/src/SPIFake.h
+++ b/src/SPIFake.h
@@ -5,6 +5,7 @@
 
 struct SPIFake {
   virtual uint8_t transfer(uint8_t data) = 0;
+  virtual uint16_t transfer16(uint16_t data) = 0;
   virtual void transfer(void *buf, size_t count) = 0;
 
   virtual void beginTransaction(SPISettings settings) = 0;

--- a/src/arduino/SPI.h
+++ b/src/arduino/SPI.h
@@ -99,6 +99,7 @@ class SPIClass {
 
   // Write to the SPI bus (MOSI pin) and also receive (MISO pin)
   virtual uint8_t transfer(uint8_t data);
+  virtual uint16_t transfer16(uint16_t data);
   virtual void transfer(void *buf, size_t count);
 
   // After performing a group of transfers and releasing the chip select

--- a/test/test_spi.h
+++ b/test/test_spi.h
@@ -7,6 +7,7 @@ namespace SpiTest {
 void test_basics(void) {
   SPISettings settings(4000000, MSBFIRST, SPI_MODE0);
   uint8_t data = 0x01;
+  uint16_t data16 = 0x1234;
   uint8_t buffer[] = {0x02, 0x03, 0x04};
   uint8_t *ptr = buffer;
 
@@ -15,11 +16,13 @@ void test_basics(void) {
   When(OverloadedMethod(ArduinoFake(SPI), beginTransaction, void(SPISettings)).Using(settings)).AlwaysReturn();
   When(OverloadedMethod(ArduinoFake(SPI), endTransaction, void(void))).AlwaysReturn();
   When(OverloadedMethod(ArduinoFake(SPI), transfer, uint8_t(uint8_t)).Using(data)).AlwaysReturn();
+  When(OverloadedMethod(ArduinoFake(SPI), transfer16, uint16_t(uint16_t)).Using(data16)).AlwaysReturn();
   When(OverloadedMethod(ArduinoFake(SPI), transfer, void(void*, size_t)).Using(ptr, sizeof(buffer))).AlwaysReturn();
 
   SPI.begin();
   SPI.beginTransaction(settings);
   SPI.transfer(data);
+  SPI.transfer16(data16);
   SPI.transfer(buffer, sizeof(buffer));
   SPI.endTransaction();
   SPI.end();
@@ -29,6 +32,7 @@ void test_basics(void) {
   Verify(OverloadedMethod(ArduinoFake(SPI), beginTransaction, void(SPISettings))).Once();
   Verify(OverloadedMethod(ArduinoFake(SPI), endTransaction, void(void))).Once();
   Verify(OverloadedMethod(ArduinoFake(SPI), transfer, uint8_t(uint8_t))).Once();
+  Verify(OverloadedMethod(ArduinoFake(SPI), transfer16, uint16_t(uint16_t))).Once();
   Verify(OverloadedMethod(ArduinoFake(SPI), transfer, void(void*, size_t))).Once();
 }
 


### PR DESCRIPTION
# Add support for `transfer16` method to SPI class in ArduinoFake

## Summary

This pull request adds support for the `transfer16` method to the `SPI` class in the ArduinoFake library, enabling 16-bit SPI data transfers for improved compatibility with Arduino code.

## Details

- Implemented the `transfer16(uint16_t)` method in the SPI and SPIFake classes.
- Updated headers and source files to declare and define the new method.
- Extended unit tests to verify correct behavior of `transfer16`.
- Ensured compatibility with existing SPI functionality and mocks.

## Motivation

Many Arduino libraries and sketches rely on `SPI.transfer16()` for 16-bit data communication. Adding this method to ArduinoFake allows users to test and simulate such code without hardware, increasing the utility and completeness of the library.

---

Thank you for reviewing this contribution!