### PR TITLE
Fix pio test

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,6 +1,14 @@
 name: Check
 
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
 
 jobs:
   build:
@@ -8,11 +16,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-22.04, windows-latest]
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Tests
         run: make
@@ -27,7 +35,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         uses: actions/cache@v3
         with:
@@ -43,5 +51,8 @@ jobs:
         name: Install PlatformIO Core
         run: pip install --upgrade platformio
       -
-        name: Tests
+        name: Build example
         run: pio test -d examples/wiring-blink/
+      -
+        name: Build Tests
+        run: pio test

--- a/external/fakeit/CMakeLists.txt
+++ b/external/fakeit/CMakeLists.txt
@@ -1,18 +1,18 @@
-cmake_minimum_required(VERSION 3.2.2)
+cmake_minimum_required(VERSION 3.14)
 project(fakeit VERSION 2.4.0 LANGUAGES CXX)
 
-include(git-download)
+include(FetchContent)
 
-set(REPO_DIR ${PROJECT_SOURCE_DIR}/${PROJECT_NAME}-repo)
-
-download_repo(
-    URL "https://github.com/eranpeer/FakeIt.git"
-    TAG ${PROJECT_VERSION}
-    CLONE_DIR ${REPO_DIR}
+FetchContent_Declare(
+    fakeit_repo
+    GIT_REPOSITORY https://github.com/eranpeer/FakeIt.git
+    GIT_TAG        ${PROJECT_VERSION}
 )
+
+FetchContent_MakeAvailable(fakeit_repo)
 
 add_library(${PROJECT_NAME} INTERFACE)
 
 target_include_directories(${PROJECT_NAME} INTERFACE
-    ${REPO_DIR}/single_header/standalone/
+    ${fakeit_repo_SOURCE_DIR}/single_header/standalone/
 )

--- a/external/unity/CMakeLists.txt
+++ b/external/unity/CMakeLists.txt
@@ -1,20 +1,19 @@
-cmake_minimum_required(VERSION 3.2.2)
+cmake_minimum_required(VERSION 3.14)
 project(unity VERSION 2.4.1 LANGUAGES C)
 
-include(git-download)
+include(FetchContent)
 
-set(REPO_DIR ${PROJECT_SOURCE_DIR}/${PROJECT_NAME}-repo)
-
-download_repo(
-    URL "https://github.com/ThrowTheSwitch/Unity.git"
-    TAG v${PROJECT_VERSION}
-    CLONE_DIR ${REPO_DIR}
+FetchContent_Declare(
+    unity_repo
+    GIT_REPOSITORY https://github.com/ThrowTheSwitch/Unity.git
+    GIT_TAG        v${PROJECT_VERSION}
 )
+FetchContent_MakeAvailable(unity_repo)
 
 add_library(${PROJECT_NAME} STATIC
-    ${REPO_DIR}/src/unity.c
+    ${unity_repo_SOURCE_DIR}/src/unity.c
 )
 
 target_include_directories(${PROJECT_NAME} PUBLIC
-    ${REPO_DIR}/src
+    ${unity_repo_SOURCE_DIR}/src
 )

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,5 +10,7 @@
 
 [env:native]
 platform = native
-build_flags = -std=gnu++17
+build_flags = 
+    -std=gnu++17 
+    -Wa,-mbig-obj
 test_build_src = yes

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -29,6 +29,11 @@ void setUp(void)
     ArduinoFakeReset();
 }
 
+void tearDown(void)
+{
+    // Nothing to do here
+}
+
 int main(int argc, char **argv)
 {
     UNITY_BEGIN();
@@ -46,9 +51,7 @@ int main(int argc, char **argv)
     RUN_TEST_GROUP(ClientTest);
     RUN_TEST_GROUP(IncludeTest);
 
-    UNITY_END();
-
-    return 0;
+    return UNITY_END();
 }
 
 #endif

--- a/test/test_context.h
+++ b/test/test_context.h
@@ -18,9 +18,28 @@ namespace ArduinoContextTest
         ArduinoFakeContext* context = getArduinoFakeContext();
         ArduinoFakeInstances* instances = context->Instances;
 
+        // Broke pointers for testing purposes
+        context->Instances->Serial = nullptr;
+        context->Instances->SPI = nullptr;
+
+        TEST_ASSERT_NULL(context->Instances->Serial);
+        TEST_ASSERT_NULL(context->Instances->SPI);
+
         ArduinoFakeReset();
 
-        TEST_ASSERT_NOT_EQUAL(context->Instances, instances);
+        // After reset, a new instance of ArduinoFakeInstances should be created
+        // and the previous instance should be deleted.
+        // The Serial and SPI instances should also be reset to nullptr.
+        TEST_ASSERT_NOT_NULL(context->Instances);
+        TEST_ASSERT_NOT_NULL(context->Instances->Serial);
+        TEST_ASSERT_NOT_NULL(context->Instances->SPI);
+
+        // A simple pointer comparison like TEST_ASSERT_NOT_EQUAL(context->Instances, instances); 
+        // is not a reliable way to check if a new instance was created, because 
+        // memory allocators can reuse the same address for new objects after deletion. 
+        // This means a new instance could be created at the same memory location as the old one, 
+        // causing the test to fail even though the instance is actually new. 
+        // To properly verify a new instance, you should check object identity or state, not just pointer values.
     }
 
     void test_function_mock(void)


### PR DESCRIPTION
# Pull Request: Fix PlatformIO Native Build and Improve Context Tests

## Summary

This pull request addresses build issues with the PlatformIO native environment and improves the reliability and clarity of context reset tests in the ArduinoFake project.

## Changes

1. **PlatformIO Build Fix**
    - Updated `[env:native]` in `platformio.ini` to add `-Wa,-mbig-obj` to `build_flags`, resolving "too many sections" and "file too big" errors on Windows with large test binaries.

2. **Test Main Improvements**
    - Added a `tearDown()` function stub to `test/main.cpp` for completeness.
    - Fixed the return value of `main()` to properly return the result of `UNITY_END()`.

3. **Context Test Enhancements**
    - In `test/test_context.h`, improved the test for context reset:
        - Explicitly broke pointers in `ArduinoFakeInstances` to ensure the reset is effective.
        - Added assertions to check that pointers are null after manual breakage and before reset.
        - Added a comment explaining why pointer comparison is not a reliable way to check for new instance creation, referencing allocator behavior and object identity.

## Example (from context test)
```cpp
// Broke pointers for testing purposes
context->Instances->Serial = nullptr;
context->Instances->SPI = nullptr;

TEST_ASSERT_NULL(context->Instances->Serial);
TEST_ASSERT_NULL(context->Instances->SPI);

ArduinoFakeReset();

TEST_ASSERT_NOT_NULL(context->Instances);
TEST_ASSERT_NOT_NULL(context->Instances->Serial);
TEST_ASSERT_NOT_NULL(context->Instances->SPI);

// A simple pointer comparison like TEST_ASSERT_NOT_EQUAL(context->Instances, instances);
// is not reliable because memory allocators can reuse the same address for new objects after deletion.
// To properly verify a new instance, you should check object identity or state, not just pointer values.
```

**Note:**  
Previous CI testing on Ubuntu did not reveal the problem in `test_context`, as the issue with pointer reuse and large object files is specific to the Windows toolchain and memory allocator behavior. The new changes ensure the tests are robust and portable across both Ubuntu and Windows environments.