### PR TITLE
Fix compilation with UBRRH or UBRRxH set

### DIFF
--- a/src/SerialFake.h
+++ b/src/SerialFake.h
@@ -4,6 +4,8 @@
 #include "StreamFake.h"
 #include "arduino/USBAPI.h"
 
+#if defined(USBCON)
+
 struct SerialFake : public StreamFake
 {
     virtual void begin(unsigned long) = 0;
@@ -46,3 +48,5 @@ class SerialFakeProxy : public StreamFakeProxy, public Serial_
             return serialFake;
         }
 };
+
+#endif // USBCON


### PR DESCRIPTION
I had to exclude the SerialFake defintions to have Serial1 etc compile when UBRR_H is set.

The implementations are already excluded unless `USBCON` is set now the definition is also excluded.

You can find the errors enclosed in the details below

<details><summary>Details</summary>

```console
In file included from .pio/libdeps/native/ArduinoFake/src/Serial.h:1,
                 from .pio/libdeps/native/ArduinoFake/src/ArduinoFake.h:18,
                 from .pio/libdeps/native/ArduinoFake/src/ClientFake.cpp:1:
.pio/libdeps/native/ArduinoFake/src/SerialFake.h:34:1: error: expected class-name before ‘{’ token
   34 | {
      | ^
In file included from .pio/libdeps/native/ArduinoFake/src/Serial.h:1,
                 from .pio/libdeps/native/ArduinoFake/src/ArduinoFake.h:18,
                 from .pio/libdeps/native/ArduinoFake/src/ArduinoFake.cpp:1:
.pio/libdeps/native/ArduinoFake/src/SerialFake.h:34:1: error: expected class-name before ‘{’ token
   34 | {
      | ^
In file included from .pio/libdeps/native/ArduinoFake/src/Serial.h:1,
                 from .pio/libdeps/native/ArduinoFake/src/ArduinoFake.h:18,
                 from test/test_00_example/test_example.cpp:1:
.pio/libdeps/native/ArduinoFake/src/SerialFake.h:34:1: error: expected class-name before ‘{’ token
   34 | {
      | ^
.pio/libdeps/native/ArduinoFake/src/ArduinoFake.h: In member function ‘SerialFake* ArduinoFakeContext::Serial(Serial_*)’:
.pio/libdeps/native/ArduinoFake/src/ArduinoFake.h:64:13: error: cannot ‘dynamic_cast’ ‘instance’ (of type ‘class Serial_*’) to type ‘class SerialFakeProxy*’ (source is a pointer to incomplete type)
   64 |         if (dynamic_cast<name##FakeProxy*>(instance)) { \
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.pio/libdeps/native/ArduinoFake/src/ArduinoFake.h:113:9: note: in expansion of macro ‘_ArduinoFakeInstanceGetter2’
  113 |         _ArduinoFakeInstanceGetter2(Serial, Serial_)
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
.pio/libdeps/native/ArduinoFake/src/ArduinoFake.h:65:20: error: cannot ‘dynamic_cast’ ‘instance’ (of type ‘class Serial_*’) to type ‘class SerialFakeProxy*’ (source is a pointer to incomplete type)
   65 |             return dynamic_cast<name##FakeProxy*>(instance)->get##name##Fake(); \
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.pio/libdeps/native/ArduinoFake/src/ArduinoFake.h:113:9: note: in expansion of macro ‘_ArduinoFakeInstanceGetter2’
  113 |         _ArduinoFakeInstanceGetter2(Serial, Serial_)
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
.pio/libdeps/native/ArduinoFake/src/ArduinoFake.h: In member function ‘SerialFake* ArduinoFakeContext::Serial(Serial_*)’:
.pio/libdeps/native/ArduinoFake/src/ArduinoFake.h:64:13: error: cannot ‘dynamic_cast’ ‘instance’ (of type ‘class Serial_*’) to type ‘class SerialFakeProxy*’ (source is a pointer to incomplete type)
   64 |         if (dynamic_cast<name##FakeProxy*>(instance)) { \
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.pio/libdeps/native/ArduinoFake/src/ArduinoFake.h:113:9: note: in expansion of macro ‘_ArduinoFakeInstanceGetter2’
  113 |         _ArduinoFakeInstanceGetter2(Serial, Serial_)
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
.pio/libdeps/native/ArduinoFake/src/ArduinoFake.h:65:20: error: cannot ‘dynamic_cast’ ‘instance’ (of type ‘class Serial_*’) to type ‘class SerialFakeProxy*’ (source is a pointer to incomplete type)
   65 |             return dynamic_cast<name##FakeProxy*>(instance)->get##name##Fake(); \
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.pio/libdeps/native/ArduinoFake/src/ArduinoFake.h:113:9: note: in expansion of macro ‘_ArduinoFakeInstanceGetter2’
  113 |         _ArduinoFakeInstanceGetter2(Serial, Serial_)
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from .pio/libdeps/native/ArduinoFake/src/Serial.h:1,
                 from .pio/libdeps/native/ArduinoFake/src/ArduinoFake.h:18,
                 from .pio/libdeps/native/ArduinoFake/src/EEPROMFake.cpp:2:
.pio/libdeps/native/ArduinoFake/src/SerialFake.h:34:1: error: expected class-name before ‘{’ token
   34 | {
      | ^
.pio/libdeps/native/ArduinoFake/src/ArduinoFake.h: In member function ‘SerialFake* ArduinoFakeContext::Serial(Serial_*)’:
.pio/libdeps/native/ArduinoFake/src/ArduinoFake.h:64:13: error: cannot ‘dynamic_cast’ ‘instance’ (of type ‘class Serial_*’) to type ‘class SerialFakeProxy*’ (source is a pointer to incomplete type)
   64 |         if (dynamic_cast<name##FakeProxy*>(instance)) { \
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.pio/libdeps/native/ArduinoFake/src/ArduinoFake.h:113:9: note: in expansion of macro ‘_ArduinoFakeInstanceGetter2’
  113 |         _ArduinoFakeInstanceGetter2(Serial, Serial_)
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
.pio/libdeps/native/ArduinoFake/src/ArduinoFake.h:65:20: error: cannot ‘dynamic_cast’ ‘instance’ (of type ‘class Serial_*’) to type ‘class SerialFakeProxy*’ (source is a pointer to incomplete type)
   65 |             return dynamic_cast<name##FakeProxy*>(instance)->get##name##Fake(); \
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.pio/libdeps/native/ArduinoFake/src/ArduinoFake.h:113:9: note: in expansion of macro ‘_ArduinoFakeInstanceGetter2’
  113 |         _ArduinoFakeInstanceGetter2(Serial, Serial_)
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
.pio/libdeps/native/ArduinoFake/src/ArduinoFake.h: In member function ‘SerialFake* ArduinoFakeContext::Serial(Serial_*)’:
.pio/libdeps/native/ArduinoFake/src/ArduinoFake.h:64:13: error: cannot ‘dynamic_cast’ ‘instance’ (of type ‘class Serial_*’) to type ‘class SerialFakeProxy*’ (source is a pointer to incomplete type)
   64 |         if (dynamic_cast<name##FakeProxy*>(instance)) { \
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.pio/libdeps/native/ArduinoFake/src/ArduinoFake.h:113:9: note: in expansion of macro ‘_ArduinoFakeInstanceGetter2’
  113 |         _ArduinoFakeInstanceGetter2(Serial, Serial_)
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
.pio/libdeps/native/ArduinoFake/src/ArduinoFake.h:65:20: error: cannot ‘dynamic_cast’ ‘instance’ (of type ‘class Serial_*’) to type ‘class SerialFakeProxy*’ (source is a pointer to incomplete type)
   65 |             return dynamic_cast<name##FakeProxy*>(instance)->get##name##Fake(); \
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.pio/libdeps/native/ArduinoFake/src/ArduinoFake.h:113:9: note: in expansion of macro ‘_ArduinoFakeInstanceGetter2’
  113 |         _ArduinoFakeInstanceGetter2(Serial, Serial_)
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
*** [.pio/build/native/libeb2/ArduinoFake/ClientFake.o] Error 1
*** [.pio/build/native/libeb2/ArduinoFake/ArduinoFake.o] Error 1
*** [.pio/build/native/libeb2/ArduinoFake/EEPROMFake.o] Error 1
*** [.pio/build/native/test/test_00_example/test_example.o] Error 1
```

</details> 