### PR TITLE
Add avr/pgmspace.h

### DIFF
--- a/src/arduino/avr/pgmspace.h
+++ b/src/arduino/avr/pgmspace.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "../pgmspace.h"


### PR DESCRIPTION
Some host code explicitly includes `<avr/pgmspace.h>`, instead of` <pgmspace.h>`